### PR TITLE
Remove support for video bitmap timestamp, rely fully on MP4-metadata timestamps; add VFR support

### DIFF
--- a/native/ffreader/src/FFReader.cpp
+++ b/native/ffreader/src/FFReader.cpp
@@ -124,6 +124,15 @@ double FFVideoReader::dts_to_sec(int64_t dts) const
  */
 int64_t FFVideoReader::dts_to_frame_number(int64_t dts) const
 {
+  // For VFR files, r_frame_rate can disagree with nb_frames/duration by ~1%,
+  // so prefer stream ticks (avg frame duration = stream->duration/nb_frames)
+  // when both are known. Falls back to fps*sec otherwise.
+  const auto *st = formatContext->streams[videoStreamIndex];
+  if (st->duration > 0 && st->nb_frames > 0)
+  {
+    int64_t delta = dts - st->start_time;
+    return (int64_t)((double)delta * st->nb_frames / (double)st->duration + 0.5);
+  }
   double sec = dts_to_sec(dts);
   return (int64_t)(getFps() * sec + 0.5);
 }
@@ -543,10 +552,19 @@ AVFrame *FFVideoReader::seekToFrame(int64_t frameNumber, bool closeTo)
        *      (= at most 31 calls, so still cheap).
        * ------------------------------------------------------------- */
 
-      int64_t start_pts = formatContext->streams[videoStreamIndex]->start_time;
-      double tb = r2d(formatContext->streams[videoStreamIndex]->time_base);
-      double sec = static_cast<double>(frameNumber) / std::max(fps, 1e-6);
-      int64_t ts = start_pts + static_cast<int64_t>(sec / tb + 0.5);
+      auto *st = formatContext->streams[videoStreamIndex];
+      int64_t start_pts = st->start_time;
+      int64_t ts;
+      if (st->duration > 0 && st->nb_frames > 0)
+      {
+        ts = start_pts + frameNumber * st->duration / st->nb_frames;
+      }
+      else
+      {
+        double tb = r2d(st->time_base);
+        double sec = static_cast<double>(frameNumber) / std::max(fps, 1e-6);
+        ts = start_pts + static_cast<int64_t>(sec / tb + 0.5);
+      }
 
       if (av_seek_frame(formatContext, videoStreamIndex, ts, AVSEEK_FLAG_BACKWARD) < 0)
         return nullptr; // seek failed (corrupt file?)
@@ -571,10 +589,18 @@ AVFrame *FFVideoReader::seekToFrame(int64_t frameNumber, bool closeTo)
   for (;;)
   {
     int64_t _frame_number_temp = std::max(frameNumber - delta, (int64_t)0);
-    double sec = (double)_frame_number_temp / fps;
-    int64_t time_stamp = formatContext->streams[videoStreamIndex]->start_time;
-    double time_base = r2d(formatContext->streams[videoStreamIndex]->time_base);
-    time_stamp += (int64_t)(sec / time_base + 0.5);
+    auto *st = formatContext->streams[videoStreamIndex];
+    int64_t time_stamp = st->start_time;
+    if (st->duration > 0 && st->nb_frames > 0)
+    {
+      time_stamp += _frame_number_temp * st->duration / st->nb_frames;
+    }
+    else
+    {
+      double sec = (double)_frame_number_temp / fps;
+      double time_base = r2d(st->time_base);
+      time_stamp += (int64_t)(sec / time_base + 0.5);
+    }
 
     if (getTotalFrames() > 1)
     {

--- a/native/ffreader/src/FFReader.cpp
+++ b/native/ffreader/src/FFReader.cpp
@@ -389,15 +389,18 @@ AVFrame *FFVideoReader::grabFrame()
     }
   }
 
-  // Compute the presentation timestamp if it's not yet set
-  if (picture_pts == AV_NOPTS_VALUE_)
+  // Trust frame->pts as set by the decoder — it's valid for both the
+  // "buffered frame" path (decoder had a frame ready) and the fresh-decode
+  // path. Previously this code overwrote frame->pts with `picture_pts`, but
+  // picture_pts is only reset inside the fresh-decode branch, so on the
+  // buffered path it would leak the PRIOR frame's pts into the current one,
+  // producing wildly non-monotonic timestamps.
+  if (frame->pts == AV_NOPTS_VALUE_)
   {
-    // If PTS is valid and nonzero, use that; otherwise, fall back on DTS
-    picture_pts = (packet->pts != AV_NOPTS_VALUE_ && packet->pts != 0)
-                      ? packet->pts
-                      : packet->dts;
+    // Decoder-supplied fallback; pkt_dts survives through decoder buffering.
+    frame->pts = frame->pkt_dts;
   }
-  frame->pts = picture_pts;
+  picture_pts = frame->pts;
   frame->time_base = formatContext->streams[videoStreamIndex]->time_base;
 
   // Calculate currentFrameNumber based on DTS

--- a/native/ffreader/src/FFReaderAPI.cpp
+++ b/native/ffreader/src/FFReaderAPI.cpp
@@ -29,6 +29,49 @@ static FrameInfoList frameInfoList;
 static FrameRect noZoom = {0, 0, 0, 0};
 static int debugLevel = 1;
 
+/**
+ * @brief Extract a 64-bit 100ns UTC timestamp from the video frame.
+ * The timestamp is encoded in the row as two pixels per bit with each bit being
+ * white for 1 and black for 0.
+ * @param image A vector containing the rgba image array
+ * @param row The row to extract the timestamp from
+ * @param width The number of columns in a row
+ * @return The extracted timestamp in milliseconds
+ */
+uint64_t extractTimestampFromFrame(const std::vector<uint8_t> &image, int row,
+                                   int width)
+{
+  uint64_t number = 0; // Initialize the 64-bit number
+
+  for (int col = 0; col < 64; col++)
+  {
+    const uint8_t pixel1 =
+        image[4 *
+              (row * width + col * 2)]; // Get the pixel at the current column
+    const uint8_t pixel2 = image[4 * (row * width + col * 2 + 1)];
+
+    // Check the pixel's color values
+    const bool isGreen = pixel1 + pixel2 > 220;
+    const uint64_t bit = isGreen ? 1 : 0;
+
+    number = (number << 1) | bit;
+  }
+
+  if (row == 0)
+  {
+    if (number == 0)
+    {
+      return extractTimestampFromFrame(image, row + 1, width);
+    }
+    else
+    {
+      return 0;
+    }
+  }
+
+  return number; // Return the timestamp in milliseconds
+}
+
 static std::shared_ptr<FrameInfo>
 getFrame(const std::unique_ptr<FFVideoReader> &ffreader,
          const std::string &filename, double frameNum, bool closeTo = false)
@@ -72,9 +115,30 @@ getFrame(const std::unique_ptr<FFVideoReader> &ffreader,
     frame->data = std::make_shared<std::vector<std::uint8_t>>(
         rgbaFrame->data[0], rgbaFrame->data[0] + totalBytes);
     frame->motion = {0, 0, 0, false};
-    auto tsMicro = ffreader->getFirstUtcUs() + 1000000 * rgbaFrame->pts * rgbaFrame->time_base.num / rgbaFrame->time_base.den;
-    frame->tsMicro = tsMicro;
-    frame->timestamp = (tsMicro + 500) / 1000;
+    if (ffreader->getFirstUtcUs() != 0)
+    {
+      // std::cerr << "Using first_utc_us from video: " << ffreader->getFirstUtcUs() << std::endl;
+      auto tsMicro = ffreader->getFirstUtcUs() + 1000000 * rgbaFrame->pts * rgbaFrame->time_base.num / rgbaFrame->time_base.den;
+      frame->tsMicro = tsMicro;
+      frame->timestamp = (tsMicro + 500) / 1000;
+      // std::cerr << "timestamp ms: " << frame->timestamp << " pts: " << rgbaFrame->pts << std::endl;
+    }
+    else
+    {
+
+      auto timestamp100ns =
+          extractTimestampFromFrame(*frame->data, 0, rgbaFrame->width);
+      auto tsMilli =
+          (5000 + timestamp100ns) / 10000; // Round 64-bit number to milliseconds
+      auto tsMicro = (5 + timestamp100ns) / 10;
+
+      if (tsMicro == 0)
+      {
+        tsMilli = uint64_t(0.5 + ((frameNum - 1) * 1000) / (frame->fps));
+      }
+      frame->tsMicro = tsMicro;
+      frame->timestamp = tsMilli;
+    }
     frameInfoList.addFrame(frame);
   }
   return frame;

--- a/native/ffreader/src/FFReaderAPI.cpp
+++ b/native/ffreader/src/FFReaderAPI.cpp
@@ -277,11 +277,50 @@ Napi::Object nativeVideoExecutor(const Napi::CallbackInfo &info)
           .ThrowAsJavaScriptException();
       return ret;
     }
-    auto frameB = getFrame(ffreader, file, frameA->numFrames);
-    if (!frameB)
+    // On VFR files, r_frame_rate can disagree with nb_frames / duration by
+    // up to ~1%, so the last requestable frame index (via dts_to_frame_number
+    // = fps * seconds) can fall short of nb_frames by up to 1% of nb_frames.
+    // Allow retries over that window (with a floor of 200 for short clips).
+    std::shared_ptr<FrameInfo> frameB;
+    const int maxBack =
+        std::max(200, static_cast<int>(frameA->numFrames / 50)); // up to 2%
+    // Exponential probe to find any reachable back-offset, then bisect to
+    // find the smallest passing back. Each getFrame() failure near EOF is
+    // expensive (full av_seek_frame + forward-decode), so linear walkback
+    // is O(maxBack) seeks — this is O(log maxBack).
+    int lo = -1; // largest known-failing back (-1 = none tried)
+    int hi = -1; // smallest known-passing back (-1 = none found)
+    for (int probe = 0; probe <= maxBack; probe = probe == 0 ? 1 : probe * 2)
     {
-      std::cerr << "Unable to read frame " << frameA->numFrames << ". Doing one less" << std::endl;
-      frameB = getFrame(ffreader, file, frameA->numFrames - 1);
+      auto f = getFrame(ffreader, file, frameA->numFrames - probe);
+      if (f)
+      {
+        frameB = f;
+        hi = probe;
+        break;
+      }
+      lo = probe;
+      if (probe == 0)
+      {
+        std::cerr << "Unable to read frame " << frameA->numFrames
+                  << ". Walking back up to " << maxBack << " frames..."
+                  << std::endl;
+      }
+      if (probe >= maxBack) break;
+    }
+    while (lo >= 0 && hi - lo > 1)
+    {
+      int mid = lo + (hi - lo) / 2;
+      auto f = getFrame(ffreader, file, frameA->numFrames - mid);
+      if (f)
+      {
+        frameB = f;
+        hi = mid;
+      }
+      else
+      {
+        lo = mid;
+      }
     }
     if (!frameB)
     {

--- a/native/ffreader/src/FFReaderAPI.cpp
+++ b/native/ffreader/src/FFReaderAPI.cpp
@@ -29,49 +29,6 @@ static FrameInfoList frameInfoList;
 static FrameRect noZoom = {0, 0, 0, 0};
 static int debugLevel = 1;
 
-/**
- * @brief Extract a 64-bit 100ns UTC timestamp from the video frame.
- * The timestamp is encoded in the row as two pixels per bit with each bit being
- * white for 1 and black for 0.
- * @param image A vector containing the rgba image array
- * @param row The row to extract the timestamp from
- * @param width The number of columns in a row
- * @return The extracted timestamp in milliseconds
- */
-uint64_t extractTimestampFromFrame(const std::vector<uint8_t> &image, int row,
-                                   int width)
-{
-  uint64_t number = 0; // Initialize the 64-bit number
-
-  for (int col = 0; col < 64; col++)
-  {
-    const uint8_t pixel1 =
-        image[4 *
-              (row * width + col * 2)]; // Get the pixel at the current column
-    const uint8_t pixel2 = image[4 * (row * width + col * 2 + 1)];
-
-    // Check the pixel's color values
-    const bool isGreen = pixel1 + pixel2 > 220;
-    const uint64_t bit = isGreen ? 1 : 0;
-
-    number = (number << 1) | bit;
-  }
-
-  if (row == 0)
-  {
-    if (number == 0)
-    {
-      return extractTimestampFromFrame(image, row + 1, width);
-    }
-    else
-    {
-      return 0;
-    }
-  }
-
-  return number; // Return the timestamp in milliseconds
-}
-
 static std::shared_ptr<FrameInfo>
 getFrame(const std::unique_ptr<FFVideoReader> &ffreader,
          const std::string &filename, double frameNum, bool closeTo = false)
@@ -115,30 +72,9 @@ getFrame(const std::unique_ptr<FFVideoReader> &ffreader,
     frame->data = std::make_shared<std::vector<std::uint8_t>>(
         rgbaFrame->data[0], rgbaFrame->data[0] + totalBytes);
     frame->motion = {0, 0, 0, false};
-    if (ffreader->getFirstUtcUs() != 0)
-    {
-      // std::cerr << "Using first_utc_us from video: " << ffreader->getFirstUtcUs() << std::endl;
-      auto tsMicro = ffreader->getFirstUtcUs() + 1000000 * rgbaFrame->pts * rgbaFrame->time_base.num / rgbaFrame->time_base.den;
-      frame->tsMicro = tsMicro;
-      frame->timestamp = (tsMicro + 500) / 1000;
-      // std::cerr << "timestamp ms: " << frame->timestamp << " pts: " << rgbaFrame->pts << std::endl;
-    }
-    else
-    {
-
-      auto timestamp100ns =
-          extractTimestampFromFrame(*frame->data, 0, rgbaFrame->width);
-      auto tsMilli =
-          (5000 + timestamp100ns) / 10000; // Round 64-bit number to milliseconds
-      auto tsMicro = (5 + timestamp100ns) / 10;
-
-      if (tsMicro == 0)
-      {
-        tsMilli = uint64_t(0.5 + ((frameNum - 1) * 1000) / (frame->fps));
-      }
-      frame->tsMicro = tsMicro;
-      frame->timestamp = tsMilli;
-    }
+    auto tsMicro = ffreader->getFirstUtcUs() + 1000000 * rgbaFrame->pts * rgbaFrame->time_base.num / rgbaFrame->time_base.den;
+    frame->tsMicro = tsMicro;
+    frame->timestamp = (tsMicro + 500) / 1000;
     frameInfoList.addFrame(frame);
   }
   return frame;

--- a/src/main/video/video-main.ts
+++ b/src/main/video/video-main.ts
@@ -2,42 +2,6 @@ import { GrabFrameMessage, nativeVideoExecutor } from 'crewtimer_video_reader';
 import { ipcMain } from 'electron';
 import { VideoFrameRequest } from 'renderer/shared/AppTypes';
 
-/**
- * Extract a 64 bit 100ns UTC timestamp from the video frame.  The timestamp
- * is encoded in the row as two pixels per bit with each bit being white for 1 and black for 0.
- * @param image A rgba image array
- * @param row The row to extract the timestamp from
- * @param width The number of columns in a row
- * @returns The extracted timestamp in milliseconds
- */
-export function extractTimestampFromFrame(
-  image: Uint8Array,
-  row: number,
-  width: number,
-): number {
-  let number = 0n; // Initialize the 64-bit number as a BigInt
-
-  for (let col = 0; col < 64; col++) {
-    const pixel1 = image[4 * (row * width + col * 2)]; // Get the pixel at the current column
-    const pixel2 = image[4 * (row * width + col * 2 + 1)];
-
-    // Check the pixel's color values
-    const isGreen = pixel1 + pixel2 > 220;
-    const bit = isGreen ? 1n : 0n;
-
-    number = number << 1n;
-
-    // Set the corresponding bit in the 64-bit number
-    number |= bit;
-  }
-
-  // console.log(`${number}`.replace('n', ''));
-
-  number = (5000n + number) / 10000n; // Round 64-bit number to milliseconds
-
-  return Number(number); // Convert the BigInt number to a regular number
-}
-
 export function stopVideoServices(_name: string) {}
 
 export function startVideoServices() {}
@@ -81,19 +45,6 @@ ipcMain.handle('video:getFrame', (_event, request: VideoFrameRequest) => {
         Object.entries(request).filter(([_, v]) => v !== undefined),
       ),
     } as unknown as GrabFrameMessage);
-    if (ret.status === 'OK') {
-      // row 0 should be black
-      // let timestamp = extractTimestampFromFrame(ret.data, 0, ret.width);
-      // if (timestamp === 0) {
-      //   timestamp = extractTimestampFromFrame(ret.data, 1, ret.width);
-      //   //console.log('extracted timestamp', timestamp);
-      //   ret.timestamp = timestamp;
-      // } else {
-      //   ret.timestamp = Math.trunc(
-      //     0.5 + ((frameNum - 1) * 1000) / (ret.fps ?? 30)
-      //   );
-      // }
-    }
     return ret;
   } catch (err) {
     return { status: `${err instanceof Error ? err.message : err}` };

--- a/src/renderer/video/RequestVideoFrame.ts
+++ b/src/renderer/video/RequestVideoFrame.ts
@@ -103,22 +103,49 @@ async function ensureFileOpen(
   openFilename = videoFile;
 
   let lastImage: AppImage | undefined;
-  for (let excessFrames = 0; excessFrames < 10; excessFrames += 1) {
+  // On VFR files, r_frame_rate may undercount the last decodable frame by
+  // up to ~1% of the total. Walk back up to 2% with a floor of 200.
+  // Each failing getFrame near EOF is an expensive native seek, so use
+  // exponential probe + bisect (O(log maxExcess)) instead of linear walk.
+  const maxExcess = Math.max(200, Math.floor(firstImage.numFrames / 50));
+  const tryBack = async (back: number): Promise<AppImage | undefined> => {
     try {
-      // eslint-disable-next-line no-await-in-loop
-      lastImage = await VideoUtils.getFrame({
+      return await VideoUtils.getFrame({
         videoFile,
-        frameNum: firstImage.numFrames - excessFrames,
+        frameNum: firstImage.numFrames - back,
         tsMilli: 0,
       });
-      firstImage.numFrames -= excessFrames;
-      break;
     } catch {
-      // Try one less frame
-      console.log(
-        `cant read frame ${firstImage.numFrames - excessFrames}, trying one less`,
-      );
+      console.log(`cant read frame ${firstImage.numFrames - back}`);
+      return undefined;
     }
+  };
+  let lo = -1; // largest known-failing back
+  let hi = -1; // smallest known-passing back
+  for (let probe = 0; probe <= maxExcess; probe = probe === 0 ? 1 : probe * 2) {
+    // eslint-disable-next-line no-await-in-loop
+    const img = await tryBack(probe);
+    if (img) {
+      lastImage = img;
+      hi = probe;
+      break;
+    }
+    lo = probe;
+    if (probe >= maxExcess) break;
+  }
+  while (lo >= 0 && hi - lo > 1) {
+    const mid = lo + Math.floor((hi - lo) / 2);
+    // eslint-disable-next-line no-await-in-loop
+    const img = await tryBack(mid);
+    if (img) {
+      lastImage = img;
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+  if (lastImage && hi > 0) {
+    firstImage.numFrames -= hi;
   }
   if (!lastImage) {
     setVideoError(`Unable to get frame ${firstImage.numFrames}: ${videoFile}`);

--- a/src/renderer/video/VideoScrubber.tsx
+++ b/src/renderer/video/VideoScrubber.tsx
@@ -67,7 +67,7 @@ const VideoScrubber = () => {
     }
 
     setVideoFrameNum(newValue);
-    requestVideoFrame({ videoFile, frameNum: newValue, closeTo: true });
+    requestVideoFrame({ videoFile, frameNum: newValue });
   };
 
   const { startTime, endTime, segments } = useMemo(() => {


### PR DESCRIPTION
Two interlocking pieces of work, plus one small UX follow-on.

  **1. Finish the migration to MP4-metadata timestamps** (per the v1.0
  spec). Reader-side support for `com.crewtimer.first_utc_us` already
  landed in ad967ac / b2f241d, gated behind a fallback to the legacy
  green-pixel-row decoder. This branch removes that fallback and fixes
  one PTS-correctness bug it was masking.

  **2. Add VFR file support.** Once timestamps come from
  `first_utc_us + pts * time_base`, files where r_frame_rate disagrees
  with duration/nb_frames break in two ways:
    - frame↔PTS math is off by up to ~1%
    - the last-frame probe at file open misses the tail of the file

  Both fixed; no behavioral change on CFR files (Glenn's NDI test
  material). VFR motivation is the high-rate Basler recorder that
  drops frames to keep the latest.

  **3. VideoScrubber.** Drop `closeTo: true` so the scrubber lands on
  the exact frame instead of the nearest keyframe.

  ## Commits (review one at a time)

  - `eba0957` ffreader: fix stale PTS leaking on the buffered-frame decode path
  - `9793959` video: drop the green-pixel-row timestamp decode path
  - `aca295e` ffreader: use stream duration/nb_frames for VFR-correct frame<->PTS math
  - `cd2405b` ffreader: bisect last-frame walkback for VFR files
  - `950f4fd` VideoScrubber: scrub to individual frames, not nearest keyframes

  ## Test plan

  - [ ] CFR (NDI camera) test files: open, scrub, play — should be
        identical to main.
  - [ ] VFR (Basler recorder) test files: open, scrub to last frame,
        verify timestamps are monotonic.
  - [ ] Confirm `closeTo: true` removal doesn't introduce scrubbing lag
        on slower hardware (Bas's testing showed no issues).