### PR TITLE
Windows: add MSYS+MSVC build path alongside Cygwin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ CrewTimer.db
 *.mkv
 *.dSym
 .qodo
+
+# Native module build artifacts
+native/ffreader/lib-build/
+native/ffreader/yarn.lock
+native/ffreader/scripts/vs-env.raw.txt
+native/ffreader/scripts/vs-env.sh

--- a/README.md
+++ b/README.md
@@ -88,6 +88,49 @@ See also [the Electron React Boilerplate page](https://electron-react-boilerplat
 4. Look in release/ for the dmg and exe files
 5. Copy the dmg and exe to a Releases set on github
 
+### Windows packaging notes
+
+When packaging on Windows from a locally-built native module (i.e. you've
+just rebuilt `crewtimer_video_reader.node` from source per
+[native/ffreader/README.md](native/ffreader/README.md)), don't run
+`yarn build:win` directly — run electron-builder yourself with
+`-c.npmRebuild=false`:
+
+```bash
+yarn build                                                    # main + renderer webpack bundles
+./node_modules/.bin/electron-builder --win -c.npmRebuild=false
+```
+
+The `-c.npmRebuild=false` flag is **required** for two reasons:
+
+1. **`sqlite3` source rebuild is broken.** Without the flag, electron-builder
+   tries to rebuild every native dep against the electron ABI. `sqlite3@5.1.7`
+   has no prebuilt for current N-API versions, falls back to `node-gyp rebuild`,
+   which fails because `sqlite3`'s bundled node-gyp install is broken.
+2. **Your locally-built `crewtimer_video_reader.node` gets silently clobbered.**
+   Even with `prebuild-install -r napi || yarn rebuild` as the install script,
+   electron-builder's rebuild step runs `prebuild-install --force` for every
+   native dep, which downloads the published prebuilt from GitHub and
+   overwrites your file at
+   `release/app/node_modules/crewtimer_video_reader/build/Release/`.
+   The packaged app then behaves like the stock release, not your source.
+   No error is shown; watch for this builder log line as a warning sign:
+   ```
+   • install prebuilt binary  name=crewtimer_video_reader version=...
+   ```
+   The line you want to see is:
+   ```
+   • skipped dependencies rebuild  reason=npmRebuild is set to false
+   ```
+
+If you've already been bitten, re-copy the freshly-built `.node` per the
+ffreader README's step 7, then re-run electron-builder with the flag, or use
+`./node_modules/.bin/electron-builder --win --prepackaged release/build/win-unpacked`
+to re-zip without touching deps.
+
+Outputs in `release/build/`: `win-unpacked/` (portable directory, ~346 MB) and
+`CrewTimer Video Review Setup <version>.exe` (NSIS installer, ~96 MB).
+
 ## Tips
 
 * Blank screen at startup? Check to make sure packagse were added top level package.json

--- a/native/ffreader/README.md
+++ b/native/ffreader/README.md
@@ -22,7 +22,153 @@ brew install cmake
 
 ### Windows Toolchain
 
-A unix like environment is needed to build ffmpeg and opencv.  Cygwin is used to establish a unix-like environment.  Install the following:
+A unix-like environment is needed to build ffmpeg and opencv. Two paths are
+supported:
+
+- **MSYS + MSVC (recommended)** — uses the bash that ships with Git for Windows
+  plus Visual Studio Build Tools 2022. No separate Cygwin install. This is the
+  path the build scripts target out of the box.
+- **Cygwin (legacy)** — Glenn's original setup. Still works; documented at the
+  bottom of this section.
+
+#### Windows Toolchain (MSYS + MSVC)
+
+One-time prerequisites:
+
+- **Visual Studio 2022 Build Tools** with the *Desktop development with C++*
+  workload (Windows 10 SDK 10.0.26100 known-good). Build Tools, Community,
+  Professional, and Enterprise editions are all auto-detected.
+  ```powershell
+  winget install Microsoft.VisualStudio.2022.BuildTools `
+    --override "--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended" `
+    --accept-package-agreements --accept-source-agreements
+  ```
+- **Git for Windows** (provides the MSYS bash shell).
+- **Node.js 18.x** + **yarn 1.22.x** (`npm install -g yarn`).
+
+Portable build tools — extract these zips under `C:\buildtools\` (no installs):
+
+| Tool            | Version           | Download                                                                                                                |
+|-----------------|-------------------|-------------------------------------------------------------------------------------------------------------------------|
+| NASM            | 2.16.03           | https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/win64/nasm-2.16.03-win64.zip                                         |
+| YASM            | 1.3.0             | http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe (rename to `yasm.exe`)                               |
+| CMake           | 3.30.5            | https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-windows-x86_64.zip                              |
+| GNU Make        | 4.4.1             | https://sourceforge.net/projects/ezwinports/files/make-4.4.1-without-guile-w32-bin.zip/download                         |
+| Strawberry Perl | 5.32.1.1 portable | https://strawberryperl.com/download/5.32.1.1/strawberry-perl-5.32.1.1-64bit-portable.zip                                |
+
+Expected layout:
+```
+C:\buildtools\
+  nasm\nasm.exe
+  yasm.exe
+  cmake\bin\cmake.exe
+  make\bin\make.exe
+  strawberry\perl\bin\perl.exe
+```
+
+Allow ~10 GB free disk for source trees, object files, and static libs.
+
+**Open a build shell.** Double-click `native/ffreader/scripts/MSYS-vstudio.bat`
+to launch a Git Bash terminal with `vcvars64.bat`'s `INCLUDE`/`LIB`/`LIBPATH`
+inherited and the portable tools on `PATH`. (To use VS Code's integrated
+terminal instead, see "Sourcing the env into another bash shell" below.)
+
+**Build OpenCV** (clean, no patches needed, ~30–60 min):
+```bash
+cd native/ffreader
+./scripts/build-opencv.sh
+```
+
+**Build FFmpeg.** This phase needs `MSYS_NO_PATHCONV=1` and
+`MSYS2_ARG_CONV_EXCL='*'` to stop MSYS from path-converting Windows-style
+arguments to MSVC. Export them once for the rest of the FFmpeg work — do
+**not** keep them set permanently (they break OpenCV's CMake/curl
+invocations, which is why they are not in `vs-env.sh`):
+
+```bash
+export MSYS_NO_PATHCONV=1 MSYS2_ARG_CONV_EXCL='*'
+./scripts/build-ffmpeg.sh
+```
+
+`build-ffmpeg.sh` will run `configure` and then fail in `make` once with two
+MSYS-specific issues. Apply the patch and resume:
+
+```bash
+# Fix the dependency-tracking awk that MSYS bash corrupts (writes ffbuild/dep.awk
+# and rewrites ffbuild/config.mak to invoke awk -f).
+node scripts/patch-config-mak.js
+
+# Resume the build. vcpkg paths must be re-exported because the previous run
+# only set them inside build-ffmpeg.sh's environment.
+FF=$(pwd)/lib-build/FFmpeg-n7.1
+VCPKG=$(cd "$(pwd)/lib-build/vcpkg/installed/x64-windows-static" && pwd -W)
+export INCLUDE="$INCLUDE;$VCPKG/include"
+export LIB="$LIB;$VCPKG/lib"
+
+cd "$FF"
+find . -name "*.o" -size 0 -delete
+find . -name "*.a" -delete
+make -j4   # MSYS_NO_PATHCONV/MSYS2_ARG_CONV_EXCL must still be exported
+```
+
+The final AR step (`lib.exe`) fails when invoked through make on MSYS — long
+arg lists get truncated at the first `\t`, producing `LNK1181: cannot open
+input file 'libavforma'`. The exact same commands run directly from bash
+succeed. Workaround:
+
+```bash
+for L in libavformat libavcodec libavutil libswscale; do rm -f $L/$L.a; done
+make -n libavformat/libavformat.a libavcodec/libavcodec.a \
+        libavutil/libavutil.a libswscale/libswscale.a 2>&1 \
+  | sed -nE 's/.*;[[:space:]]*(lib\.exe[[:space:]].*)/\1/p' > /tmp/ar-cmds.sh
+bash /tmp/ar-cmds.sh
+make install                             # MSYS env still required
+cd ../
+rm -rf ffmpeg-static-win
+cp -a ffmpeg-static-win-x86_64 ffmpeg-static-win
+```
+
+(FFmpeg n7.1's `make -n` emits each AR step as
+`printf "AR\t%s\n" target.a; lib.exe ...`, so `grep "^lib.exe"` won't catch
+them — the sed extracts the `lib.exe ...` portion after the `;`.)
+
+**Build the `.node` and use it:**
+```bash
+cd native/ffreader
+yarn install --network-timeout 600000
+npx node-gyp rebuild --arch=x64
+cp build/Release/crewtimer_video_reader.node \
+   ../../release/app/node_modules/crewtimer_video_reader/build/Release/
+```
+
+**Sourcing the env into another bash shell.** If you want to build from VS
+Code's integrated terminal or any bash session that wasn't launched via
+`MSYS-vstudio.bat`, generate a sourceable env file once:
+
+```bash
+cmd.exe //c "scripts\\dump-vs-env.bat > scripts\\vs-env.raw.txt"
+node scripts/make-env.js
+# Then in any bash session:
+source native/ffreader/scripts/vs-env.sh
+```
+
+**Known gotchas** (covered above; collected here for reference):
+
+| Symptom                                                                 | Cause                                                  | Fix                                       |
+|-------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------|
+| `cl.exe not found` after sourcing env                                   | `vcvars64 >nul` suppressed `INCLUDE`/`LIB`             | `dump-vs-env.bat` does not redirect stdout |
+| FFmpeg configure: `ERROR: zlib requested but not found`                 | vcpkg path passed as `/c/...` to `cl.exe`              | `pwd -W` MSYS branch in `build-ffmpeg.sh` |
+| `awk: unterminated regexp` on every compile                             | MSYS bash strips one `\` from inline awk arg           | `node scripts/patch-config-mak.js`        |
+| `LNK1181: cannot open input file 'libavforma'`                          | MSYS arg-passing corrupts long AR command              | Run `lib.exe` directly from bash          |
+| `node-gyp rebuild` can't find `libavcodec/avcodec.h` under `release/app`| `binding.gyp` paths are relative to `native/ffreader`  | Build in `native/ffreader/`, copy `.node` |
+
+For the app-level packaging step (electron-builder + NSIS installer) and the
+`-c.npmRebuild=false` flag that's required on Windows, see the top-level
+[README.md](../../README.md#windows-packaging-notes).
+
+#### Windows Toolchain (Cygwin, legacy)
+
+Glenn's original setup. Install the following:
 
 - [nvm for windows](https://github.com/coreybutler/nvm-windows/releases)
 - [git for windows](https://gitforwindows.org/)

--- a/native/ffreader/scripts/MSYS-vstudio.bat
+++ b/native/ffreader/scripts/MSYS-vstudio.bat
@@ -1,0 +1,41 @@
+@echo off
+setlocal enableextensions
+set TERM=
+
+:: Locate vcvars64.bat across common VS 2022 editions (Build Tools, Community,
+:: Professional, Enterprise). Last match wins; adjust order if you have multiple.
+set "VS_VCVARS="
+for %%I in (
+  "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+) do if exist %%~I set "VS_VCVARS=%%~I"
+
+if not defined VS_VCVARS (
+  echo ERROR: could not find vcvars64.bat for Visual Studio 2022.
+  echo Install the "Desktop development with C++" workload from VS Build Tools 2022.
+  exit /b 1
+)
+
+call "%VS_VCVARS%"
+
+:: Prepend the portable build tools that the FFmpeg/OpenCV builds need.
+:: See native/ffreader/README.md "Windows Toolchain (MSYS + MSVC)" for layout.
+set PATH=C:\buildtools\nasm;C:\buildtools\make\bin;C:\buildtools\strawberry\perl\bin;C:\buildtools;C:\buildtools\cmake\bin;%PATH%
+
+:: NOTE: MSYS_NO_PATHCONV and MSYS2_ARG_CONV_EXCL are NOT set here on purpose.
+:: Setting them globally breaks OpenCV's CMake/curl invocations. They are only
+:: needed for the FFmpeg build; export them in your bash shell just before
+:: running build-ffmpeg.sh, per native/ffreader/README.md.
+
+:: Move to native/ffreader (parent of scripts/)
+set BATCH_DIR=%~dp0
+cd "%BATCH_DIR%.."
+
+:: Launch Git Bash. INCLUDE/LIB/LIBPATH set by vcvars64 are inherited as-is
+:: (MSYS does not path-convert these), so cl.exe resolves them correctly.
+set "GIT_BASH=C:\Program Files\Git\bin\bash.exe"
+if not exist "%GIT_BASH%" set "GIT_BASH=C:\Program Files\Git\usr\bin\bash.exe"
+"%GIT_BASH%" --login -i

--- a/native/ffreader/scripts/build-ffmpeg.sh
+++ b/native/ffreader/scripts/build-ffmpeg.sh
@@ -6,6 +6,11 @@ BASE_BUILD_DIR="$PWD/lib-build"
 if [[ "$OSTYPE" == "cygwin" ]]; then
   BASE_BUILD_DIR=`cygpath -m "${BASE_BUILD_DIR}"`
   echo BASE_BUILD_DIR=${BASE_BUILD_DIR}
+elif [[ "$OSTYPE" == "msys" ]]; then
+  # Convert /c/path -> C:/path. Don't use `pwd -W` here: the dir may not exist
+  # yet (mkdir -p happens further down) and `cd` to it would silently no-op.
+  BASE_BUILD_DIR=$(echo "$BASE_BUILD_DIR" | sed -E 's|^/([a-zA-Z])/|\1:/|')
+  echo BASE_BUILD_DIR=${BASE_BUILD_DIR}
 fi
 
 # Determine the platform (macOS or Windows via WSL or others)
@@ -57,8 +62,14 @@ if [[ "$PLATFORM" == "win" ]]; then
   else
     echo "vcpkg already installed in $BASE_BUILD_DIR/vcpkg."
   fi
-  if [ ! -f "$BASE_BUILD_DIR/vcpkg/installed/x64-windows-static/lib/zlib.lib" ]; then
+  VCPKG_LIB_DIR="$BASE_BUILD_DIR/vcpkg/installed/x64-windows-static/lib"
+  if [ ! -f "$VCPKG_LIB_DIR/zlib.lib" ] && [ ! -f "$VCPKG_LIB_DIR/zs.lib" ]; then
      (cd "$BASE_BUILD_DIR/vcpkg" && ./vcpkg install zlib:x64-windows-static)
+  fi
+  # Recent vcpkg versions install zlib as zs.lib (renamed to avoid clashes).
+  # FFmpeg's configure looks specifically for zlib.lib, so alias it.
+  if [ -f "$VCPKG_LIB_DIR/zs.lib" ] && [ ! -f "$VCPKG_LIB_DIR/zlib.lib" ]; then
+    cp "$VCPKG_LIB_DIR/zs.lib" "$VCPKG_LIB_DIR/zlib.lib"
   fi
 
   # ffmpeg configure needs to be able to find these packages

--- a/native/ffreader/scripts/dump-vs-env.bat
+++ b/native/ffreader/scripts/dump-vs-env.bat
@@ -1,0 +1,34 @@
+@echo off
+:: Captures the env set up by vcvars64.bat plus the portable build tools so a
+:: bash session (e.g. VS Code's integrated terminal) can source it without
+:: going through MSYS-vstudio.bat. Pair with make-env.js, which converts the
+:: dump to a bash-sourceable vs-env.sh.
+::
+:: Usage (from cmd or git-bash):
+::   cmd.exe /c scripts\dump-vs-env.bat > scripts\vs-env.raw.txt
+::   node scripts\make-env.js
+::   source scripts/vs-env.sh
+::
+:: NOTE: do NOT redirect vcvars's stdout to nul here. Doing so causes vcvars
+:: to silently skip setting INCLUDE/LIB/LIBPATH on some installs. Let it print
+:: its banner and capture the whole stream.
+
+setlocal enableextensions
+
+set "VS_VCVARS="
+for %%I in (
+  "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+  "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+) do if exist %%~I set "VS_VCVARS=%%~I"
+
+if not defined VS_VCVARS (
+  echo ERROR: could not find vcvars64.bat for Visual Studio 2022. 1>&2
+  exit /b 1
+)
+
+call "%VS_VCVARS%"
+set PATH=C:\buildtools\nasm;C:\buildtools\make\bin;C:\buildtools\strawberry\perl\bin;C:\buildtools;C:\buildtools\cmake\bin;%PATH%
+set

--- a/native/ffreader/scripts/make-env.js
+++ b/native/ffreader/scripts/make-env.js
@@ -1,0 +1,52 @@
+// Convert the cmd-style env dump from dump-vs-env.bat into a bash-sourceable
+// vs-env.sh. PATH is rewritten to MSYS-style (/c/...); INCLUDE/LIB/LIBPATH are
+// kept as native Windows path lists (MSYS does not path-convert these env
+// vars, so cl.exe resolves them correctly).
+//
+// Usage:
+//   cmd.exe /c scripts\dump-vs-env.bat > scripts\vs-env.raw.txt
+//   node scripts/make-env.js
+//   source scripts/vs-env.sh
+const fs = require('fs');
+const path = require('path');
+
+const here = __dirname;
+const rawPath = path.join(here, 'vs-env.raw.txt');
+const outPath = path.join(here, 'vs-env.sh');
+
+if (!fs.existsSync(rawPath)) {
+  console.error('vs-env.raw.txt not found. Run dump-vs-env.bat first:');
+  console.error('  cmd.exe /c scripts\\dump-vs-env.bat > scripts\\vs-env.raw.txt');
+  process.exit(1);
+}
+
+const raw = fs.readFileSync(rawPath, 'utf8');
+const env = {};
+for (const line of raw.split(/\r?\n/)) {
+  const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+  if (m) env[m[1]] = m[2];
+}
+
+const strip = s => (s || '').replace(/\\+$/, '');
+const winPathToMsys = winPath =>
+  (winPath || '')
+    .split(';')
+    .filter(Boolean)
+    .map(e => {
+      e = e.replace(/\\/g, '/').replace(/\/+$/, '');
+      const drive = e.match(/^([A-Za-z]):\//);
+      if (drive) e = '/' + drive[1].toLowerCase() + '/' + e.slice(3);
+      return e;
+    })
+    .join(':');
+
+const out =
+`# Auto-generated VS build env. Do not edit; rerun scripts/make-env.js to refresh.
+export PATH="/c/buildtools/nasm:/c/buildtools/make/bin:/c/buildtools/strawberry/perl/bin:/c/buildtools:/c/buildtools/cmake/bin:${winPathToMsys(env.PATH)}:$PATH"
+export INCLUDE='${strip(env.INCLUDE)}'
+export LIB='${strip(env.LIB)}'
+export LIBPATH='${strip(env.LIBPATH)}'
+`;
+
+fs.writeFileSync(outPath, out);
+console.log('wrote ' + outPath);

--- a/native/ffreader/scripts/patch-config-mak.js
+++ b/native/ffreader/scripts/patch-config-mak.js
@@ -1,0 +1,75 @@
+// MSYS-only fixup for FFmpeg's dependency-tracking awk invocation.
+//
+// FFmpeg's configure emits inline awk in ffbuild/config.mak that contains a
+// regex with a backslash escape. MSYS bash strips one backslash on the way
+// to make/awk, corrupting the regex and failing every source compile with
+// "awk: unterminated regexp". The fix is to extract the awk program into a
+// script file and invoke it via `awk -f`, so nothing has to round-trip
+// through the shell.
+//
+// Usage (from native/ffreader/, after build-ffmpeg.sh's configure step):
+//   node scripts/patch-config-mak.js
+//
+// Idempotent. Locates FFmpeg-* under lib-build/ automatically.
+
+const fs = require('fs');
+const path = require('path');
+
+const ffreaderDir = path.resolve(__dirname, '..');
+const libBuild = path.join(ffreaderDir, 'lib-build');
+
+if (!fs.existsSync(libBuild)) {
+  console.error('lib-build/ not found at', libBuild);
+  console.error('Run scripts/build-ffmpeg.sh first to fetch FFmpeg sources.');
+  process.exit(1);
+}
+
+const ffmpegDirs = fs
+  .readdirSync(libBuild)
+  .filter(name => /^FFmpeg-/.test(name))
+  .map(name => path.join(libBuild, name))
+  .filter(p => fs.statSync(p).isDirectory());
+
+if (ffmpegDirs.length === 0) {
+  console.error('No FFmpeg-* directory under', libBuild);
+  process.exit(1);
+}
+if (ffmpegDirs.length > 1) {
+  console.error('Multiple FFmpeg-* directories under lib-build/, refusing to guess:');
+  for (const d of ffmpegDirs) console.error('  ' + d);
+  process.exit(1);
+}
+
+const ffmpegDir = ffmpegDirs[0];
+const ffbuild = path.join(ffmpegDir, 'ffbuild');
+const configMak = path.join(ffbuild, 'config.mak');
+const depAwk = path.join(ffbuild, 'dep.awk');
+
+if (!fs.existsSync(configMak)) {
+  console.error('config.mak not found at', configMak);
+  console.error('Run scripts/build-ffmpeg.sh through its configure step first.');
+  process.exit(1);
+}
+
+// Write the awk program as a standalone file so MSYS's shell does not eat
+// the backslash in the regex.
+fs.writeFileSync(
+  depAwk,
+  '/including/ { sub(/^.*file: */, ""); gsub(/\\\\/, "/"); if (!match($0, / /)) print TARGET ":", $0 }\n',
+);
+
+// Replace inline awk invocations (CCDEP, CXXDEP, ASDEP, HOSTCCDEP) with the
+// scripted form. Idempotent: re-running is a no-op once patched.
+const before = fs.readFileSync(configMak, 'utf8');
+const after = before.replace(
+  /awk '\/including\/[^']*'/g,
+  `awk -v TARGET="$@" -f ffbuild/dep.awk`,
+);
+
+if (before === after) {
+  console.log('config.mak already patched (no inline awk found).');
+} else {
+  fs.writeFileSync(configMak, after);
+  console.log('Patched ' + configMak);
+}
+console.log('Wrote ' + depAwk);


### PR DESCRIPTION
Provides an alternative to the existing Cygwin instructions, using Git for Windows' MSYS bash + Visual Studio 2022 Build Tools. Validated end-to-end on a clean machine through a working NSIS installer build.

- New helpers in native/ffreader/scripts/: MSYS-vstudio.bat (entry shell, sibling of Cygwin-vstudio.bat), dump-vs-env.bat + make-env.js (capture vcvars64 env into a sourceable vs-env.sh for VS Code etc.), patch-config-mak.js (auto-fix the MSYS awk-regex bug in FFmpeg's config.mak).
- build-ffmpeg.sh: msys path-conversion branch, plus zs.lib -> zlib.lib alias for recent vcpkg releases that renamed the static zlib output.
- native/ffreader/README.md: new MSYS subsection; legacy Cygwin docs preserved verbatim.
- README.md: Windows packaging notes for electron-builder -c.npmRebuild=false (without it, prebuild-install --force silently overwrites locally-built .node files).
- .gitignore: exclude lib-build/, ffreader yarn.lock, and the env-capture helpers' generated outputs.